### PR TITLE
Add direct Send-to-Claude flow (backend + UI)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,31 @@ I'm the GitHub Learning Lab bot and I'm here to help guide you in your journey t
 I'll meet you over there, can't wait to get started!
 
 This course is using the :sparkles: open source project [reveal.js](https://github.com/hakimel/reveal.js/). In some cases we’ve made changes to the history so it would behave during class, so head to the original project repo to learn more about the cool people behind this project.
+
+## MCP upload studio + Claude Desktop integration
+
+`mcp-ui/` now includes:
+
+- A polished web UI for multi-file uploads and previews.
+- A local JSON data store used by both the UI server and Claude Desktop MCP server.
+- A Claude Desktop MCP stdio server (`mcp-ui/claude-desktop-mcp.js`) that can read all uploaded files.
+
+### Start the UI server
+
+```bash
+npm start
+```
+
+Open `http://localhost:3000`.
+
+### Connect to Claude Desktop
+
+1. In the UI, use **Send to Claude Desktop → Load Claude config snippet**.
+2. Copy the snippet into your Claude Desktop `mcpServers` config.
+3. Restart Claude Desktop.
+4. Use **Send selected files to Claude** in the UI to directly open Claude Desktop with a prepared prompt; payload is also copied as fallback.
+
+The MCP server exposed to Claude Desktop has tools:
+
+- `list_uploaded_files`
+- `get_file_content`

--- a/mcp-ui/claude-desktop-mcp.js
+++ b/mcp-ui/claude-desktop-mcp.js
@@ -1,0 +1,138 @@
+const fs = require('fs');
+const path = require('path');
+
+const DEFAULT_STORE = path.join(__dirname, 'data', 'uploads.json');
+const STORE_FILE = process.env.FILE_INGEST_STORE || DEFAULT_STORE;
+
+function readStore() {
+  if (!fs.existsSync(STORE_FILE)) {
+    return [];
+  }
+
+  try {
+    const parsed = JSON.parse(fs.readFileSync(STORE_FILE, 'utf8'));
+    return Array.isArray(parsed.files) ? parsed.files : [];
+  } catch {
+    return [];
+  }
+}
+
+function summarize(file) {
+  return {
+    id: file.id,
+    createdAt: file.createdAt,
+    name: file.name,
+    mimeType: file.mimeType,
+    size: file.size,
+    contentType: file.content?.type || 'unknown'
+  };
+}
+
+function makeResponse(id, result) {
+  return { jsonrpc: '2.0', id, result };
+}
+
+function makeError(id, message) {
+  return { jsonrpc: '2.0', id, error: { code: -32602, message } };
+}
+
+function handleRequest(msg) {
+  const { id, method, params } = msg || {};
+
+  if (method === 'initialize') {
+    return makeResponse(id, {
+      protocolVersion: '2024-11-05',
+      serverInfo: { name: 'file-ingest-ui-stdio', version: '2.0.0' },
+      capabilities: { tools: {} }
+    });
+  }
+
+  if (method === 'tools/list') {
+    return makeResponse(id, {
+      tools: [
+        {
+          name: 'list_uploaded_files',
+          description: 'List uploaded files from the UI ingestion store.',
+          inputSchema: { type: 'object', properties: {} }
+        },
+        {
+          name: 'get_file_content',
+          description: 'Get complete metadata/content for an uploaded file by id.',
+          inputSchema: {
+            type: 'object',
+            properties: { id: { type: 'string' } },
+            required: ['id']
+          }
+        }
+      ]
+    });
+  }
+
+  if (method === 'tools/call') {
+    const toolName = params?.name;
+    const args = params?.arguments || {};
+    const files = readStore();
+
+    if (toolName === 'list_uploaded_files') {
+      return makeResponse(id, {
+        content: [{ type: 'text', text: JSON.stringify(files.map(summarize), null, 2) }]
+      });
+    }
+
+    if (toolName === 'get_file_content') {
+      const selected = files.find((file) => file.id === args.id);
+      if (!selected) {
+        return makeError(id, 'Unknown file id');
+      }
+      return makeResponse(id, {
+        content: [{ type: 'text', text: JSON.stringify(selected, null, 2) }]
+      });
+    }
+
+    return makeError(id, `Unknown tool: ${toolName}`);
+  }
+
+  if (method === 'notifications/initialized') {
+    return null;
+  }
+
+  return makeError(id, `Unsupported method: ${method}`);
+}
+
+function writeFramed(payload) {
+  const body = Buffer.from(JSON.stringify(payload), 'utf8');
+  const header = Buffer.from(`Content-Length: ${body.length}\r\n\r\n`, 'utf8');
+  process.stdout.write(Buffer.concat([header, body]));
+}
+
+let buffer = Buffer.alloc(0);
+process.stdin.on('data', (chunk) => {
+  buffer = Buffer.concat([buffer, chunk]);
+
+  while (true) {
+    const headerEnd = buffer.indexOf('\r\n\r\n');
+    if (headerEnd === -1) break;
+
+    const headerText = buffer.subarray(0, headerEnd).toString('utf8');
+    const lenMatch = headerText.match(/Content-Length:\s*(\d+)/i);
+    if (!lenMatch) {
+      buffer = buffer.subarray(headerEnd + 4);
+      continue;
+    }
+
+    const contentLength = Number(lenMatch[1]);
+    const totalLength = headerEnd + 4 + contentLength;
+    if (buffer.length < totalLength) break;
+
+    const jsonPayload = buffer.subarray(headerEnd + 4, totalLength).toString('utf8');
+    buffer = buffer.subarray(totalLength);
+
+    try {
+      const request = JSON.parse(jsonPayload);
+      const response = handleRequest(request);
+      if (response) writeFramed(response);
+    } catch {
+      writeFramed(makeError(null, 'Invalid JSON payload'));
+    }
+  }
+});

--- a/mcp-ui/file-store.js
+++ b/mcp-ui/file-store.js
@@ -1,0 +1,77 @@
+const fs = require('fs');
+const path = require('path');
+
+const DATA_DIR = path.join(__dirname, 'data');
+const DATA_FILE = path.join(DATA_DIR, 'uploads.json');
+
+function ensureStore() {
+  if (!fs.existsSync(DATA_DIR)) {
+    fs.mkdirSync(DATA_DIR, { recursive: true });
+  }
+  if (!fs.existsSync(DATA_FILE)) {
+    fs.writeFileSync(DATA_FILE, JSON.stringify({ files: [] }, null, 2));
+  }
+}
+
+function readStore() {
+  ensureStore();
+  const raw = fs.readFileSync(DATA_FILE, 'utf8');
+  const parsed = JSON.parse(raw || '{"files":[]}');
+  return Array.isArray(parsed.files) ? parsed.files : [];
+}
+
+function writeStore(files) {
+  ensureStore();
+  fs.writeFileSync(DATA_FILE, JSON.stringify({ files }, null, 2));
+}
+
+function isTextType(name, mimeType) {
+  const ext = path.extname(name || '').toLowerCase();
+  const textExtensions = new Set(['.txt', '.md', '.json', '.csv', '.html', '.xml', '.yaml', '.yml', '.js', '.ts']);
+  return textExtensions.has(ext) || (mimeType || '').startsWith('text/');
+}
+
+function normalizeUpload(file) {
+  const id = `${Date.now()}-${Math.random().toString(16).slice(2, 10)}`;
+  const raw = Buffer.from(file.base64 || '', 'base64');
+
+  const content = isTextType(file.name, file.mimeType)
+    ? { type: 'text', value: raw.toString('utf8') }
+    : {
+      type: 'binary',
+      value: `Binary file (${file.mimeType || 'unknown'}) with ${raw.length} bytes`,
+      base64Preview: raw.subarray(0, Math.min(raw.length, 160)).toString('base64')
+    };
+
+  return {
+    id,
+    createdAt: new Date().toISOString(),
+    name: file.name,
+    mimeType: file.mimeType || 'application/octet-stream',
+    size: raw.length,
+    content
+  };
+}
+
+function addFiles(uploadedFiles) {
+  const existing = readStore();
+  const normalized = uploadedFiles.map(normalizeUpload);
+  const next = existing.concat(normalized);
+  writeStore(next);
+  return normalized;
+}
+
+function listFiles() {
+  return readStore();
+}
+
+function getFileById(id) {
+  return readStore().find((file) => file.id === id);
+}
+
+module.exports = {
+  DATA_FILE,
+  addFiles,
+  listFiles,
+  getFileById
+};

--- a/mcp-ui/public/index.html
+++ b/mcp-ui/public/index.html
@@ -1,0 +1,236 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>MCP Upload Studio</title>
+    <style>
+      :root {
+        --bg: #070b1a;
+        --card: rgba(255, 255, 255, 0.09);
+        --text: #e7ecff;
+        --muted: #b5c1ff;
+        --accent: #7c4dff;
+        --accent-2: #00c2ff;
+      }
+      * { box-sizing: border-box; }
+      body {
+        margin: 0;
+        font-family: Inter, Segoe UI, Arial, sans-serif;
+        color: var(--text);
+        background: radial-gradient(circle at 10% 20%, #2e1a5f 0%, transparent 40%),
+          radial-gradient(circle at 95% 10%, #063a6b 0%, transparent 35%),
+          linear-gradient(160deg, #050712, #0d1530 55%, #090b17);
+        min-height: 100vh;
+      }
+      .container { max-width: 1120px; margin: 0 auto; padding: 2.5rem 1.25rem 3rem; }
+      h1 { margin: 0; font-size: 2.2rem; }
+      .hero { display: grid; grid-template-columns: 1.4fr 1fr; gap: 1rem; margin-bottom: 1rem; }
+      .glass {
+        background: var(--card);
+        border: 1px solid rgba(255,255,255,.18);
+        border-radius: 20px;
+        padding: 1rem 1.1rem;
+        backdrop-filter: blur(12px);
+        box-shadow: 0 12px 38px rgba(0, 0, 0, 0.45);
+      }
+      .subtitle { color: var(--muted); line-height: 1.6; margin-top: .6rem; }
+      .metric { font-size: 2rem; font-weight: 700; margin-top: .2rem; }
+      .row { display:flex; flex-wrap:wrap; gap:.75rem; align-items:center; }
+      .panel { margin-top: 1rem; }
+      .grid { display:grid; grid-template-columns: 1fr 1fr; gap:1rem; }
+      button, .fileInput {
+        border: 0;
+        border-radius: 12px;
+        padding: .62rem 1rem;
+        font-weight: 600;
+      }
+      button {
+        cursor:pointer;
+        color:white;
+        background: linear-gradient(120deg, var(--accent), #5a67ff 55%, var(--accent-2));
+        transition: transform .15s ease;
+      }
+      button:hover { transform: translateY(-1px); }
+      .ghost { background: rgba(255,255,255,.08); border: 1px solid rgba(255,255,255,.18); }
+      .fileInput { background: rgba(255,255,255,.16); color: white; }
+      ul { list-style: none; padding: 0; margin: .25rem 0 0; max-height: 360px; overflow: auto; }
+      li { padding: .5rem 0; border-bottom: 1px solid rgba(255,255,255,.1); }
+      .fileBtn { width: 100%; text-align: left; background: transparent; padding: .15rem 0; color: var(--text); }
+      pre {
+        white-space: pre-wrap;
+        background: #040612;
+        border: 1px solid rgba(255,255,255,.12);
+        border-radius: 14px;
+        padding: .8rem;
+        min-height: 330px;
+        overflow: auto;
+      }
+      .muted { color: var(--muted); font-size: .92rem; }
+      @media (max-width: 900px) { .hero, .grid { grid-template-columns: 1fr; } }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <section class="hero">
+        <article class="glass">
+          <h1>MCP Upload Studio</h1>
+          <p class="subtitle">Upload many file types, preview what got indexed, and wire the same dataset directly into Claude Desktop through MCP stdio transport.</p>
+          <div class="row">
+            <input id="files" class="fileInput" type="file" multiple />
+            <button id="upload">Upload files</button>
+            <button id="refresh" class="ghost">Refresh</button>
+          </div>
+          <p id="status" class="muted">Ready.</p>
+        </article>
+        <aside class="glass">
+          <div class="muted">Indexed files</div>
+          <div id="fileCount" class="metric">0</div>
+          <div class="muted">The Claude Desktop MCP server reads this same local store.</div>
+        </aside>
+      </section>
+
+      <section class="grid panel">
+        <article class="glass">
+          <h2>Uploaded files</h2>
+          <p class="muted">Choose which files to send directly to Claude Desktop.</p>
+          <ul id="fileList"></ul>
+        </article>
+
+        <article class="glass">
+          <h2>File preview</h2>
+          <pre id="content">Select a file from the left to inspect parsed content.</pre>
+        </article>
+      </section>
+
+      <section class="glass panel">
+        <h2>Send to Claude Desktop</h2>
+        <p class="muted">Click below to fetch a ready-to-paste `mcpServers` config snippet for Claude Desktop.</p>
+        <div class="row">
+          <button id="loadConfig">Load Claude config snippet</button>
+          <button id="copyConfig" class="ghost">Copy snippet</button>
+          <button id="sendToClaude">Send selected files to Claude</button>
+        </div>
+        <pre id="claudeConfig">No snippet loaded yet.</pre>
+      </section>
+    </div>
+
+    <script>
+      const fileList = document.getElementById('fileList');
+      const content = document.getElementById('content');
+      const status = document.getElementById('status');
+      const fileCount = document.getElementById('fileCount');
+      const claudeConfig = document.getElementById('claudeConfig');
+
+      function toBase64(file) {
+        return new Promise((resolve, reject) => {
+          const reader = new FileReader();
+          reader.onload = () => resolve(String(reader.result).split(',')[1] || '');
+          reader.onerror = reject;
+          reader.readAsDataURL(file);
+        });
+      }
+
+      async function refreshFiles() {
+        const res = await fetch('/api/files');
+        const data = await res.json();
+        fileList.innerHTML = '';
+        fileCount.textContent = data.files.length;
+
+        data.files.forEach((file) => {
+          const li = document.createElement('li');
+          li.innerHTML = `<label class="row"><input type="checkbox" class="sendCheck" value="${file.id}" /><button class="fileBtn" data-id="${file.id}">${file.name}</button></label><div class="muted">${file.mimeType} · ${file.size} bytes · ${file.contentType}</div>`;
+          fileList.appendChild(li);
+        });
+
+        document.querySelectorAll('.fileBtn').forEach((btn) => {
+          btn.addEventListener('click', async () => {
+            const res = await fetch(`/api/files/${btn.dataset.id}`);
+            const data = await res.json();
+            content.textContent = JSON.stringify(data, null, 2);
+          });
+        });
+      }
+
+      document.getElementById('upload').addEventListener('click', async () => {
+        const input = document.getElementById('files');
+        if (!input.files.length) {
+          status.textContent = 'Please select one or more files.';
+          return;
+        }
+
+        status.textContent = 'Uploading...';
+        const files = await Promise.all(Array.from(input.files).map(async (file) => ({
+          name: file.name,
+          mimeType: file.type,
+          base64: await toBase64(file)
+        })));
+
+        const res = await fetch('/api/upload', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ files })
+        });
+        const data = await res.json();
+
+        if (!res.ok) {
+          status.textContent = data.error || 'Upload failed';
+          return;
+        }
+
+        status.textContent = `Uploaded ${data.uploaded.length} file(s).`;
+        input.value = '';
+        refreshFiles();
+      });
+
+      document.getElementById('refresh').addEventListener('click', refreshFiles);
+
+      document.getElementById('loadConfig').addEventListener('click', async () => {
+        const res = await fetch('/api/claude-desktop-config');
+        const data = await res.json();
+        claudeConfig.textContent = JSON.stringify(data.configSnippet, null, 2);
+      });
+
+      document.getElementById('copyConfig').addEventListener('click', async () => {
+        try {
+          await navigator.clipboard.writeText(claudeConfig.textContent);
+          status.textContent = 'Claude config snippet copied.';
+        } catch {
+          status.textContent = 'Clipboard copy failed. Copy manually from the snippet box.';
+        }
+      });
+
+      document.getElementById('sendToClaude').addEventListener('click', async () => {
+        const selectedIds = Array.from(document.querySelectorAll('.sendCheck:checked')).map((node) => node.value);
+        const res = await fetch('/api/claude/send', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ fileIds: selectedIds })
+        });
+        const data = await res.json();
+
+        if (!res.ok) {
+          status.textContent = data.error || 'Failed to prepare Claude payload.';
+          return;
+        }
+
+        claudeConfig.textContent = data.payload;
+
+        try {
+          await navigator.clipboard.writeText(data.payload);
+          status.textContent = 'Payload copied. Opening Claude Desktop...';
+        } catch {
+          status.textContent = 'Could not copy automatically. Opening Claude Desktop with deep-link attempt.';
+        }
+
+        try {
+          window.location.href = data.claudeDeepLink;
+        } catch {
+          status.textContent = 'Deep-link launch failed. Paste payload into Claude Desktop manually.';
+        }
+      });
+
+      refreshFiles();
+    </script>
+  </body>
+</html>

--- a/mcp-ui/server.js
+++ b/mcp-ui/server.js
@@ -1,0 +1,212 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+const { addFiles, listFiles, getFileById, DATA_FILE } = require('./file-store');
+
+const PORT = Number(process.env.PORT) || 3000;
+const PUBLIC_DIR = path.join(__dirname, 'public');
+const MCP_STDIO_PATH = path.join(__dirname, 'claude-desktop-mcp.js');
+
+function json(res, status, payload) {
+  res.writeHead(status, { 'Content-Type': 'application/json; charset=utf-8' });
+  res.end(JSON.stringify(payload));
+}
+
+function parseBody(req) {
+  return new Promise((resolve, reject) => {
+    let body = '';
+    req.on('data', (chunk) => {
+      body += chunk;
+      if (body.length > 10 * 1024 * 1024) {
+        reject(new Error('Request too large'));
+      }
+    });
+    req.on('end', () => {
+      if (!body) return resolve({});
+      try {
+        resolve(JSON.parse(body));
+      } catch {
+        reject(new Error('Invalid JSON'));
+      }
+    });
+    req.on('error', reject);
+  });
+}
+
+function summarize(file) {
+  return {
+    id: file.id,
+    createdAt: file.createdAt,
+    name: file.name,
+    mimeType: file.mimeType,
+    size: file.size,
+    contentType: file.content.type
+  };
+}
+
+function buildClaudePayload(fileIds) {
+  const files = listFiles();
+  const selected = Array.isArray(fileIds) && fileIds.length > 0
+    ? files.filter((file) => fileIds.includes(file.id))
+    : files.slice(-5);
+
+  const blocks = selected.map((file) => {
+    const header = `### ${file.name} (${file.mimeType}, ${file.size} bytes)`;
+    if (file.content.type === 'text') {
+      const preview = String(file.content.value || '').slice(0, 14000);
+      return `${header}\n${preview}`;
+    }
+
+    return `${header}\n${file.content.value}\nbase64Preview=${file.content.base64Preview || ''}`;
+  });
+
+  return [
+    'Use the following uploaded files as context:',
+    '',
+    ...blocks
+  ].join('\n\n');
+}
+
+function handleMcp(body, res) {
+  const { id, method, params } = body || {};
+  const ok = (result) => json(res, 200, { jsonrpc: '2.0', id, result });
+  const fail = (message) => json(res, 400, { jsonrpc: '2.0', id, error: { code: -32602, message } });
+
+  if (method === 'initialize') {
+    return ok({
+      protocolVersion: '2024-11-05',
+      serverInfo: { name: 'file-ingest-mcp-ui-http', version: '2.0.0' },
+      capabilities: { tools: {} }
+    });
+  }
+
+  if (method === 'tools/list') {
+    return ok({
+      tools: [
+        {
+          name: 'list_uploaded_files',
+          description: 'List uploaded files available to Claude Desktop.',
+          inputSchema: { type: 'object', properties: {} }
+        },
+        {
+          name: 'get_file_content',
+          description: 'Return file metadata and extracted content by file id.',
+          inputSchema: {
+            type: 'object',
+            properties: { id: { type: 'string' } },
+            required: ['id']
+          }
+        }
+      ]
+    });
+  }
+
+  if (method === 'tools/call') {
+    const toolName = params?.name;
+    const args = params?.arguments || {};
+
+    if (toolName === 'list_uploaded_files') {
+      const list = listFiles().map(summarize);
+      return ok({ content: [{ type: 'text', text: JSON.stringify(list, null, 2) }] });
+    }
+
+    if (toolName === 'get_file_content') {
+      const file = getFileById(args.id);
+      if (!file) return fail('Unknown file id');
+      return ok({ content: [{ type: 'text', text: JSON.stringify(file, null, 2) }] });
+    }
+
+    return fail(`Unknown tool: ${toolName}`);
+  }
+
+  return fail(`Unsupported method: ${method}`);
+}
+
+function serveStatic(req, res) {
+  const target = req.url === '/' ? '/index.html' : req.url;
+  const filePath = path.join(PUBLIC_DIR, target);
+
+  if (!filePath.startsWith(PUBLIC_DIR)) {
+    res.writeHead(403);
+    return res.end('Forbidden');
+  }
+
+  fs.readFile(filePath, (err, data) => {
+    if (err) {
+      res.writeHead(404);
+      return res.end('Not found');
+    }
+
+    const ext = path.extname(filePath);
+    const mime = ext === '.html'
+      ? 'text/html; charset=utf-8'
+      : ext === '.css'
+        ? 'text/css; charset=utf-8'
+        : 'text/plain; charset=utf-8';
+    res.writeHead(200, { 'Content-Type': mime });
+    res.end(data);
+  });
+}
+
+const server = http.createServer(async (req, res) => {
+  try {
+    if (req.method === 'POST' && req.url === '/api/upload') {
+      const body = await parseBody(req);
+      const uploadedFiles = Array.isArray(body.files) ? body.files : [];
+      if (uploadedFiles.length === 0) return json(res, 400, { error: 'No files uploaded' });
+      return json(res, 200, { uploaded: addFiles(uploadedFiles).map(summarize) });
+    }
+
+    if (req.method === 'GET' && req.url === '/api/files') {
+      return json(res, 200, { files: listFiles().map(summarize) });
+    }
+
+    if (req.method === 'GET' && req.url.startsWith('/api/files/')) {
+      const id = decodeURIComponent(req.url.replace('/api/files/', ''));
+      const file = getFileById(id);
+      if (!file) return json(res, 404, { error: 'File not found' });
+      return json(res, 200, file);
+    }
+
+    if (req.method === 'GET' && req.url === '/api/claude-desktop-config') {
+      return json(res, 200, {
+        message: 'Paste this into Claude Desktop config under mcpServers.',
+        configSnippet: {
+          'file-ingest-ui': {
+            command: 'node',
+            args: [MCP_STDIO_PATH],
+            env: {
+              FILE_INGEST_STORE: DATA_FILE
+            }
+          }
+        }
+      });
+    }
+
+    if (req.method === 'POST' && req.url === '/mcp') {
+      const body = await parseBody(req);
+      return handleMcp(body, res);
+    }
+
+    if (req.method === 'POST' && req.url === '/api/claude/send') {
+      const body = await parseBody(req);
+      const payload = buildClaudePayload(body.fileIds);
+      return json(res, 200, {
+        message: 'Payload prepared for Claude Desktop deep-link and clipboard fallback.',
+        payload,
+        claudeDeepLink: `claude://new?prompt=${encodeURIComponent(payload)}`
+      });
+    }
+
+    if (req.method === 'GET') return serveStatic(req, res);
+
+    res.writeHead(405);
+    return res.end('Method not allowed');
+  } catch (error) {
+    return json(res, 500, { error: error.message });
+  }
+});
+
+server.listen(PORT, () => {
+  console.log(`MCP UI server running at http://localhost:${PORT}`);
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "github-slideshow-mcp-ui",
+  "version": "2.0.0",
+  "private": true,
+  "description": "MCP server with web UI for multi-file ingestion and Claude Desktop bridge",
+  "main": "mcp-ui/server.js",
+  "scripts": {
+    "start": "node mcp-ui/server.js",
+    "mcp:claude": "node mcp-ui/claude-desktop-mcp.js",
+    "lint": "node --check mcp-ui/server.js && node --check mcp-ui/claude-desktop-mcp.js && node --check mcp-ui/file-store.js"
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a way to directly open Claude Desktop with uploaded file context from the MCP Upload Studio instead of only offering a config snippet.
- Make it easy to select which uploaded files should be included in the prompt sent to Claude Desktop.

### Description
- Added a backend endpoint `POST /api/claude/send` which builds a Claude-ready prompt from selected uploaded files (or recent files by default) via `buildClaudePayload` and returns `payload` and a `claudeDeepLink` (`claude://new?prompt=...`).
- Updated the UI at `mcp-ui/public/index.html` to add file-selection checkboxes and a `Send selected files to Claude` button that calls the new endpoint, copies the payload to the clipboard, attempts to open Claude Desktop via deep-link, and displays the payload as a manual fallback.
- Kept and surfaced the existing MCP stdio bridge (`mcp-ui/claude-desktop-mcp.js`) and persistent file store (`mcp-ui/file-store.js`) so the UI and Claude Desktop bridge share the same dataset, and updated the README usage guidance.

### Testing
- Ran `npm run lint` which completed successfully and checked `mcp-ui/server.js`, `mcp-ui/claude-desktop-mcp.js`, and `mcp-ui/file-store.js`.
- Started the server (`node mcp-ui/server.js`) and confirmed it logs the server URL and served the UI successfully.
- Verified upload and direct-send flows using `curl` by `POST /api/upload` followed by `POST /api/claude/send`, which returned the expected `payload` and `claudeDeepLink` JSON.
- Captured a UI screenshot with Playwright (Firefox) to validate the new send button and selection UI, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998306f105c83248bcdacef3c3738c1)